### PR TITLE
Run debug builds on master branch pushes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,8 @@ name: Pull Request
 on:
   pull_request:
     branches: [ master ]
+  push:
+    branches: [ master ]
 
 jobs:
   ktlint:
@@ -49,7 +51,7 @@ jobs:
       - name: Validate Lint
         run: ./gradlew lint
 
-  pr_build:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This runs debug builds on master branch pushes in order to populate the github actions cache via the Gradle build action for faster PR builds. I'm assuming that since this is an OSS project the github action runners are free so there is no cost to this.


<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->